### PR TITLE
Addressed validation errors for SQL Materialized View swagger changes

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/cosmos-db.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/cosmos-db.json
@@ -2148,6 +2148,9 @@
           },
           "CosmosDBSqlContainerRestore": {
             "$ref": "./examples/CosmosDBSqlContainerRestore.json"
+          },
+          "CosmosDBSqlMaterializedViewCreateUpdate": {
+            "$ref": "./examples/CosmosDBSqlMaterializedViewCreateUpdate.json"
           }
         },
         "description": "Create or update an Azure Cosmos DB SQL container",
@@ -9430,6 +9433,11 @@
       "type": "object",
       "description": "Materialized View definition for the container.",
       "properties": {
+        "sourceCollectionRid": {
+          "description": "An unique identifier for the source collection. This is a system generated property.",
+          "type": "string",
+          "readOnly": true
+        },
         "sourceCollectionId": {
           "description": "The name of the source container on which the Materialized View will be created.",
           "type": "string"

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/examples/CosmosDBSqlMaterializedViewCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/examples/CosmosDBSqlMaterializedViewCreateUpdate.json
@@ -1,83 +1,84 @@
 {
   "parameters": {
-      "accountName": "ddb1",
-      "resourceGroupName": "rg1",
-      "api-version": "2022-11-15-preview",
-      "subscriptionId": "subid",
-      "databaseName": "databaseName",
-      "containerName": "mvContainerName",
-      "createUpdateSqlContainerParameters": {
-          "location": "West US",
-          "tags": {},
-          "properties": {
-              "resource": {
-                  "id": "mvContainerName",
-                  "partitionKey": {
-                      "paths": [
-                          "/pk"
-                      ],
-                      "kind": "Hash"
-                  },
-                  "materializedViewDefinition": {
-                      "sourceCollectionId": "sourceContainerName",
-                      "definition": "select * from ROOT"
-                  }
-              },
-              "options": {}
+    "accountName": "ddb1",
+    "resourceGroupName": "rg1",
+    "api-version": "2022-11-15-preview",
+    "subscriptionId": "subid",
+    "databaseName": "databaseName",
+    "containerName": "mvContainerName",
+    "createUpdateSqlContainerParameters": {
+      "location": "West US",
+      "tags": {},
+      "properties": {
+        "resource": {
+          "id": "mvContainerName",
+          "partitionKey": {
+            "paths": [
+              "/pk"
+            ],
+            "kind": "Hash"
+          },
+          "materializedViewDefinition": {
+            "sourceCollectionId": "sourceContainerName",
+            "definition": "select * from ROOT"
           }
+        },
+        "options": {}
       }
+    }
   },
   "responses": {
-      "200": {
-          "body": {
-              "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1/sqlDatabases/databaseName/containers/mvContainerName",
-              "name": "mvContainerName",
-              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/sqlContainers",
-              "location": "West US",
-              "tags": {},
-              "properties": {
-                  "resource": {
-                      "id": "mvContainerName",
-                      "indexingPolicy": {
-                          "indexingMode": "consistent",
-                          "automatic": true,
-                          "includedPaths": [{
-                                  "path": "/*"
-                              }
-                          ],
-                          "excludedPaths": [{
-                                  "path": "/\"_etag\"/?"
-                              }
-                          ]
-                      },
-                      "partitionKey": {
-                          "paths": ["/pk"],
-                          "kind": "Hash"
-                      },
-                      "defaultTtl": -1,
-                      "uniqueKeyPolicy": {
-                          "uniqueKeys": []
-                      },
-                      "conflictResolutionPolicy": {
-                          "mode": "LastWriterWins",
-                          "conflictResolutionPath": "/_ts",
-                          "conflictResolutionProcedure": ""
-                      },
-                      "geospatialConfig": {
-                          "type": "Geography"
-                      },
-                      "materializedViewDefinition": {
-                          "sourceCollectionRid": "e9N-s6Ua-4Y=",
-                          "sourceCollectionId": "sourceContainerName",
-                          "definition": "select * from ROOT"
-                      },
-                      "_rid": "e9N-s+nr644=",
-                      "_ts": 1666700363,
-                      "_etag": "\"00004700-0000-0800-0000-6357d44b0000\""
-                  }
-              }
+    "200": {
+      "body": {
+        "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1/sqlDatabases/databaseName/containers/mvContainerName",
+        "name": "mvContainerName",
+        "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/sqlContainers",
+        "location": "West US",
+        "tags": {},
+        "properties": {
+          "resource": {
+            "id": "mvContainerName",
+            "indexingPolicy": {
+              "indexingMode": "consistent",
+              "automatic": true,
+              "includedPaths": [
+                {
+                  "path": "/*"
+                }
+              ],
+              "excludedPaths": [
+                {
+                  "path": "/\"_etag\"/?"
+                }
+              ]
+            },
+            "partitionKey": {
+              "paths": [
+                "/pk"
+              ],
+              "kind": "Hash"
+            },
+            "defaultTtl": -1,
+            "uniqueKeyPolicy": {
+              "uniqueKeys": []
+            },
+            "conflictResolutionPolicy": {
+              "mode": "LastWriterWins",
+              "conflictResolutionPath": "/_ts",
+              "conflictResolutionProcedure": ""
+            },
+            "materializedViewDefinition": {
+              "sourceCollectionRid": "e9N-s6Ua-4Y=",
+              "sourceCollectionId": "sourceContainerName",
+              "definition": "select * from ROOT"
+            },
+            "_rid": "e9N-s+nr644=",
+            "_ts": 1666700363,
+            "_etag": "\"00004700-0000-0800-0000-6357d44b0000\""
           }
-      },
-      "202": {}
+        }
+      }
+    },
+    "202": {}
   }
 }

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/examples/CosmosDBSqlMaterializedViewCreateUpdate.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-11-15-preview/examples/CosmosDBSqlMaterializedViewCreateUpdate.json
@@ -12,9 +12,31 @@
       "properties": {
         "resource": {
           "id": "mvContainerName",
+          "indexingPolicy": {
+            "indexingMode": "consistent",
+            "automatic": true,
+            "includedPaths": [
+              {
+                "path": "/*",
+                "indexes": [
+                  {
+                    "kind": "Range",
+                    "dataType": "String",
+                    "precision": -1
+                  },
+                  {
+                    "kind": "Range",
+                    "dataType": "Number",
+                    "precision": -1
+                  }
+                ]
+              }
+            ],
+            "excludedPaths": []
+          },
           "partitionKey": {
             "paths": [
-              "/pk"
+              "/mvpk"
             ],
             "kind": "Hash"
           },
@@ -54,7 +76,7 @@
             },
             "partitionKey": {
               "paths": [
-                "/pk"
+                "/mvpk"
               ],
               "kind": "Hash"
             },
@@ -68,13 +90,13 @@
               "conflictResolutionProcedure": ""
             },
             "materializedViewDefinition": {
-              "sourceCollectionRid": "e9N-s6Ua-4Y=",
+              "sourceCollectionRid": "vb0sn6nEu9A=",
               "sourceCollectionId": "sourceContainerName",
               "definition": "select * from ROOT"
             },
-            "_rid": "e9N-s+nr644=",
-            "_ts": 1666700363,
-            "_etag": "\"00004700-0000-0800-0000-6357d44b0000\""
+            "_rid": "vb0sn8MDxLw=",
+            "_ts": 1671427656,
+            "_etag": "\"00000800-0000-0200-0000-639ff6480000\""
           }
         }
       }


### PR DESCRIPTION
In this PR, I have fixed the following validation errors -
1. Avacado: The example was not referenced from the swagger spec
2. Swagger PrettierCheck: Prettified the example file
3. Model Validation: Added sourceCollectionRid as readonly property to be shown only as part of responses 